### PR TITLE
Update ch06_Regression_Analysis.ipynb

### DIFF
--- a/ch06_Regression_Analysis.ipynb
+++ b/ch06_Regression_Analysis.ipynb
@@ -797,7 +797,7 @@
     "x = ice2.year\n",
     "y = ice2.extent\n",
     "plt.scatter(x, y, color = 'red')\n",
-    "plt.xlabel('Month')\n",
+    "plt.xlabel('Year')\n",
     "plt.ylabel('Extent')"
    ]
   },


### PR DESCRIPTION
Following the cleaning of the ice data set, the fig. drawn for the year-extent relation should have been labeled as year-extent instead of month-extent.