### PR TITLE
Parameters for calculating the r2_score

### DIFF
--- a/ch06_Regression_Analysis.ipynb
+++ b/ch06_Regression_Analysis.ipynb
@@ -1218,7 +1218,7 @@
     "plt.xlabel('year')\n",
     "plt.ylabel('extent (All months)')\n",
     "print(\"MSE:\", metrics.mean_squared_error(y_hat, y))\n",
-    "print(\"R^2:\", metrics.r2_score(y_hat, y))\n",
+    "print(\"R^2:\", metrics.r2_score(y, y_hat))\n",
     "print(\"var:\", y.var())"
    ]
   },


### PR DESCRIPTION
As per the documentation, the metrics.r2_score expected 2 parameters, the first should be the true values 'y' and the second should be the predicted values 'y_hat'.